### PR TITLE
Minimize the creation of client objects.

### DIFF
--- a/app/src/App.jsx
+++ b/app/src/App.jsx
@@ -54,7 +54,7 @@ function App() {
       receiveError: console.error,
     });
     setClient(newClient);
-    setMessage('{}');
+    prepopulate({ ...JSON.parse(message), messagingHandle: messageHandle });
     return () => {
       console.log('APP: disabling an expired swm client');
       newClient.disable();

--- a/app/src/App.jsx
+++ b/app/src/App.jsx
@@ -34,7 +34,7 @@ function App() {
   const clientHolder = useRef(null);
 
   useEffect(() => {
-    console.debug('creating a new swm client in the app');
+    console.debug('APP: creating a new swm client');
     const newClient = new swm.Client(messageHandle, targetOrigin);
     newClient.enable({
       receiveResponse: (r) => {
@@ -44,7 +44,7 @@ function App() {
     });
     clientHolder.current = newClient;
     return () => {
-      console.log('disabling an expired swm client in the app');
+      console.log('APP: disabling an expired swm client');
       newClient.disable();
     }
   }, [targetOrigin, messageHandle]);

--- a/app/src/App.jsx
+++ b/app/src/App.jsx
@@ -46,6 +46,7 @@ function App() {
     }
 
     const newClient = new swm.Client(messageHandle, targetOrigin);
+    console.debug('APP: enabling new swm client');
     newClient.enable({
       receiveResponse: (r) => {
         setResponse(JSON.stringify(r, null, 2));
@@ -53,6 +54,7 @@ function App() {
       receiveError: console.error,
     });
     setClient(newClient);
+    setMessage('{}');
     return () => {
       console.log('APP: disabling an expired swm client');
       newClient.disable();


### PR DESCRIPTION
It was noted that the demo app was creating a new client for each rendering.  Instead, use the react setState to create a new client only when needed.